### PR TITLE
Toggle changes

### DIFF
--- a/PnlStagePatch.cs
+++ b/PnlStagePatch.cs
@@ -15,22 +15,17 @@ internal static class PnlStagePatch
             ActivateAllHidden();
         }
 
-        GameObject vSelect = null;
-        foreach (var @object in __instance.transform.parent.parent.Find("Forward"))
-        {
-            var transform = @object.Cast<Transform>();
-            if (transform.name == "PnlVolume")
-            {
-                vSelect = transform.gameObject;
-            }
-        }
+        GameObject vSelect = __instance.transform.parent.parent.Find("Forward")?.Find("PnlVolume")?.gameObject;
 
         if (QolToggle != null || vSelect == null)
         {
             return;
         }
 
-        QolToggle = Object.Instantiate(vSelect.transform.Find("LogoSetting").Find("Toggles").Find("TglOn").gameObject, __instance.transform);
+        QolToggle = Object.Instantiate(
+            vSelect.transform.Find("LogoSetting").Find("Toggles").Find("TglOn").gameObject, 
+            __instance.stageAchievementPercent.transform
+            );
         SetupToggle();
     }
 }

--- a/QolManager.cs
+++ b/QolManager.cs
@@ -1,5 +1,6 @@
 using Il2CppAssets.Scripts.Database;
 using Il2CppAssets.Scripts.PeroTools.Commons;
+using Il2CppAssets.Scripts.PeroTools.GeneralLocalization;
 using Il2CppAssets.Scripts.PeroTools.Nice.Events;
 using Il2CppAssets.Scripts.PeroTools.Nice.Variables;
 using UnityEngine.Events;
@@ -126,10 +127,11 @@ internal static class QoLManager
         var background = QolToggle.transform.Find("Background").GetChild(0).GetComponent<Image>();
         var toggle = QolToggle.GetComponent<Toggle>();
         QolToggle.transform.position = new Vector3(-7f, -5f, 100f);
-        QolToggle.GetComponent<OnToggle>().enabled = false;
-        QolToggle.GetComponent<OnToggleOn>().enabled = false;
-        QolToggle.GetComponent<OnActivate>().enabled = false;
-        QolToggle.GetComponent<VariableBehaviour>().enabled = false;
+        UnityEngine.Object.Destroy(QolToggle.GetComponent<OnToggle>());
+        UnityEngine.Object.Destroy(QolToggle.GetComponent<OnToggleOn>());
+        UnityEngine.Object.Destroy(QolToggle.GetComponent<OnActivate>());
+        UnityEngine.Object.Destroy(QolToggle.GetComponent<VariableBehaviour>());
+        UnityEngine.Object.Destroy(text.GetComponent<Localization>());
         toggle.group = null;
         toggle.SetIsOnWithoutNotify(Setting.QolEnabled);
         toggle.onValueChanged.AddListener((UnityAction<bool>)


### PR DESCRIPTION
# Toggle changes
Modify the toggle implementation to avoid unwanted behaviour and to improve its visuals
## Motivation
When changing the localization of the game, the toggle text reverts to the text of the original toggle. Also, modifying the value of the toggle modifies the value of the original toggle. On the other hand, the toggle stays fixed on its position, instead of following the UI.

## Changes
* Changing the way the reference is obtained by using `Find`.
* Removing the extra components that are left unused, including the `Localization` component.  This removes the unwanted behaviour.
* Using `__instance.stageAchievementPercent.transform` instead of `__instance.transform` to use the same parent used in the UI components that are close to the toggle.

